### PR TITLE
Added globalemu to reionisation and 21cm section

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ In cosmology, the process of [Reionization](https://en.wikipedia.org/wiki/Reioni
 | *21cmVAE: A VAE-based Emulator of the 21-cm Global Signal* | VAE | https://arxiv.org/abs/2107.05581 |
 | *Probing Ultra-light Axion Dark Matter from 21cm Tomography using Convolutional Neural Networks* | CNN | https://arxiv.org/abs/2108.07972 |
 | *GLOBALEMU: A novel and robust approach for emulating the sky-averaged 21-cm signal from the cosmic dawn and epoch of reionisation* | NN | https://arxiv.org/abs/2104.04336 |
+| *Emulating the Global 21-cm Signal from Cosmic Dawn and Reionization* | NN | https://arxiv.org/abs/1910.06274 |
 
 &nbsp;
 ---


### PR DESCRIPTION
Added a paper detailing the open source python 21-cm signal emulator [globalemu](https://github.com/htjb/globalemu) to the "Reionization and 21cm" section. 

The paper uses neural networks to emulate the global 21-cm signal and offers a quicker alternative to [21cmGEM](https://arxiv.org/abs/1910.06274) and [21cmVAE](https://github.com/christianhbye/21cmVAE) without sacrificing accuracy.